### PR TITLE
Only resolve azure nsg if not passed in config

### DIFF
--- a/cloud-provider.sh
+++ b/cloud-provider.sh
@@ -12,6 +12,7 @@ set_azure_config() {
   local azure_client_id=$(cat "$AZURE_CLOUD_CONFIG_PATH" | jq -r .aadClientId)
   local azure_client_secret=$(cat "$AZURE_CLOUD_CONFIG_PATH" | jq -r .aadClientSecret)
   local azure_tenant_id=$(cat "$AZURE_CLOUD_CONFIG_PATH" | jq -r .tenantId)
+  local az_vm_nsg=$(cat "$AZURE_CLOUD_CONFIG_PATH" | jq -r .securityGroupName)
 
   # setting correct login cloud
   if [ "${azure_cloud}" = "null" ] || [ "${azure_cloud}" = "" ]; then
@@ -26,7 +27,10 @@ set_azure_config() {
   local az_subnet_name=$(az vm nic show -g ${az_resources_group} --vm-name ${az_vm_name} --nic ${az_vm_nic}| jq -r .ipConfigurations[0].subnet.id| cut -d"/" -f 11)
   local az_vnet_name=$(az vm nic show -g ${az_resources_group} --vm-name ${az_vm_name} --nic ${az_vm_nic}| jq -r .ipConfigurations[0].subnet.id| cut -d"/" -f 9)
   local az_vnet_resource_group=$(az vm nic show -g ${az_resources_group} --vm-name ${az_vm_name} --nic ${az_vm_nic}| jq -r .ipConfigurations[0].subnet.id| cut -d"/" -f 5)
-  local az_vm_nsg=$(az vm nic show -g ${az_resources_group} --vm-name ${az_vm_name} --nic ${az_vm_nic} | jq -r .networkSecurityGroup.id | cut -d "/" -f 9)
+
+  if [ -z "$az_vm_nsg" ] ; then
+    az_vm_nsg=$(az vm nic show -g ${az_resources_group} --vm-name ${az_vm_name} --nic ${az_vm_nic} | jq -r .networkSecurityGroup.id | cut -d "/" -f 9)
+  fi
 
   az logout 2>&1 > /dev/null
 


### PR DESCRIPTION
In some environments there are no NSGs connected to VMs. If this is the case then the resolution in cloud-provider.sh returns "null". Besides that it is still valid to provide the nsg in the rke configutaion file, but this is literally ignored at the moment.

Here I would suggest that the configuration in the rke config should be preferred. So if the parameter securityGroupName is set in the rke configuration then this value should be used and if it is not set then the name should be resolved automatically via the current procedure.
