### PR TITLE
get az_location from META_URL if not set in cloud config

### DIFF
--- a/cloud-provider.sh
+++ b/cloud-provider.sh
@@ -32,6 +32,10 @@ set_azure_config() {
     az_resources_group="$az_vm_resources_group"
   fi
 
+  if [ -z "$az_location" ]; then
+    az_location=$(curl  -s -H Metadata:true "${AZURE_META_URL}/location?api-version=2017-08-01&format=text")
+  fi
+
   local az_vm_nic=$(az vm nic list -g ${az_resources_group} --vm-name ${az_vm_name} | jq -r .[0].id | cut -d "/" -f 9)
 
   if [ -z "$az_subnet_name" ] ; then


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/20632

Test steps, 
1) Created a cluster with correct subscriptionID, cluster got created successfully and became active.
2) Created cluster with incorrect subscriptionID (but correct subscriptionID in node template) - cluster still gets created successfully and becomes active. But the cloud provider specific features won't work. This can be seen by checking `kube-controller-manager` logs, 

```
E0627 02:04:40.042715       1 service_controller.go:219] error processing service kube-system/metrics-server (will retry): error getting LB for service kube-system/metrics-server: network.LoadBalancersClient#List: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="SubscriptionNotFound" Message="The subscription 'zzzzzz-14a619f7-a887-4635-8647-d8f46f92eaac' could not be found."
``` 
Also, confirmed the incorrect subscriptionID was passed by checking `kube-controller-manager` logs, 
```
local az_subscription_id=zzzz-14a619f7-a887-4635-8647-d8f46f92eaac
``` 

Note:
If you see any unclear error msgs in UI while provisioning clusters, like 
```
[workerPlane] Failed to bring up Worker Plane: [Failed to verify healthcheck: Failed to check https://localhost:10250/healthz for service [kubelet] on host [40.78.127.185]: Get https://localhost:10250/healthz: dial tcp 127.0.0.1:10250: connect: connection refused, log: + az login --service-principal -u REDACTED -p REDACTED --tenant REDACTED]
``` 
we should first check `kube-controller-manger` logs, for this msg: 
```
'Some variables were not populated correctly, using the passed config!'
``` 
most likely, one of the required values is missing and needs to be accounted for. (Which happened for this bug, when the location wasn't passed.) 