### PR TITLE
etcdctl 3.3 does not accept/ignore brackets

### DIFF
--- a/main.go
+++ b/main.go
@@ -316,7 +316,7 @@ func CreateBackup(backupName string, etcdCACert, etcdCert, etcdKey, endpoints st
 		}
 		// check if the cluster is healthy
 		cmd := exec.Command("etcdctl",
-			fmt.Sprintf("--endpoints=[%s]", endpoints),
+			fmt.Sprintf("--endpoints=%s", endpoints),
 			"--cacert="+etcdCACert,
 			"--cert="+etcdCert,
 			"--key="+etcdKey,
@@ -332,7 +332,7 @@ func CreateBackup(backupName string, etcdCACert, etcdCert, etcdKey, endpoints st
 		}
 
 		cmd = exec.Command("etcdctl",
-			fmt.Sprintf("--endpoints=[%s]", endpoints),
+			fmt.Sprintf("--endpoints=%s", endpoints),
 			"--cacert="+etcdCACert,
 			"--cert="+etcdCert,
 			"--key="+etcdKey,


### PR DESCRIPTION
Problem: etcdctl was bumped from 3.0 to 3.3, etcdctl 3.3 does not accept the use of brackets in the --endpoints flag (--endpoints=[https://0.0.0.0:2379]) while 3.0 accepted/ignored it

Solution: remove brackets (they are not specified in the docs either)