### PR TITLE
Linkmode external breaks binary execution

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,5 +6,5 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rke-etcd-backup


### PR DESCRIPTION
Golang was bumped to v1.12.9 in rke-tools v0.1.41, see below:

```
$ docker run rancher/rke-tools:v0.1.41 bash -c "/opt/rke-tools/rke-etcd-backup --help 2>&1"
bash: line 1:     7 Trace/breakpoint trap   /opt/rke-tools/rke-etcd-backup --help 2>&1
```