### PR TITLE
Fixed could not add Windows worker with Azure CP

### DIFF
--- a/windows/cloud-provider.psm1
+++ b/windows/cloud-provider.psm1
@@ -90,7 +90,6 @@ function Complete-AzureCloudConfig
 
         # override
         $azCloudConfigOverrided = @{
-            cloud = $azureCloud
             subscriptionId = $azSubscriptionId
             location = $azLocation
             resourceGroup = $azResourcesGroup


### PR DESCRIPTION
**Problem:**
Failed to add Windows worker with Azure cloud provider

**Solution:**
Don't fill back the `cloud` field of the cloud-config file when it is blank

**Issue:**
https://github.com/rancher/rancher/issues/22406