### PR TITLE
Fixed getting wrong internal address in host-gw

### DIFF
--- a/windows/sidecar.ps1
+++ b/windows/sidecar.ps1
@@ -126,10 +126,10 @@ if ($networkConfigObj)
                 }
                 "host-gw" {
                     $networkAddress = ""
-                    if ($nodeAddress)  {
-                        $networkAddress = $nodeAddress
-                    } elseif ($nodeInternalAddress) {
+                    if ($nodeInternalAddress) {
                         $networkAddress = $nodeInternalAddress
+                    } elseif ($nodeAddress)  {
+                        $networkAddress = $nodeAddress
                     }
 
                     $networkMetadataJSON = wins.exe cli net get --address "$networkAddress"


### PR DESCRIPTION
**Problem:**
Windows kubelet could not detect the appropriate network adapter by itself.

**Solution:**
Patch the --node-ip with default network adapter if not pass internal address.

**Issue:**
https://github.com/rancher/rancher/issues/22475