### PR TITLE
set azure_cloud based on tokens from Azure/go-autorest

### DIFF
--- a/cloud-provider.sh
+++ b/cloud-provider.sh
@@ -21,9 +21,12 @@ set_azure_config() {
   local az_vm_name=$(curl -s -H Metadata:true "${AZURE_META_URL}/name?api-version=2017-08-01&format=text")
 
   # setting correct login cloud
-  if [ "${azure_cloud}" = "null" ] || [ "${azure_cloud}" = "" ]; then
-      azure_cloud="AzureCloud"
-  fi
+  case "${azure_cloud}" in
+    "AZURECHINACLOUD")        azure_cloud="AzureChinaCloud" ;;
+    "AZUREGERMANCLOUD")       azure_cloud="AzureGermanCloud" ;;
+    "AZUREUSGOVERNMENTCLOUD") azure_cloud="AzureUSGovernment" ;;
+    *)                        azure_cloud="AzureCloud" ;;
+  esac
   az cloud set --name ${azure_cloud}
 
   # login to Azure


### PR DESCRIPTION
This PR resolves an issue where nodes fail to deploy in non-public Azure cloud environments.  The tokens used to select the environment by azcli and the Azure/go-autorest library are different, but only one can be specified in the UI.  This PR allows the user to enter the cloud environment name defined in go-autorest and still correctly select the cloud used by azcli. Currently nodes cannot be provisioned in other Azure cloud environments besides the public one (default).  I have successfully deployed to the US Gov environment using an rke-tools container with the updated script.

azcli values:
```
az cloud list --output table
IsActive    Name               Profile
----------  -----------------  ---------
False       AzureCloud         latest
False       AzureChinaCloud    latest
True        AzureUSGovernment  latest
False       AzureGermanCloud   latest
```

From https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go#L34
```
var environments = map[string]Environment{
	"AZURECHINACLOUD":        ChinaCloud,
	"AZUREGERMANCLOUD":       GermanCloud,
	"AZUREPUBLICCLOUD":       PublicCloud,
	"AZUREUSGOVERNMENTCLOUD": USGovernmentCloud,
}
```

This is related to: https://github.com/rancher/rancher/issues/23350