### PR TITLE
Fix could not recognize non-English system

### DIFF
--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -34,7 +34,7 @@ RUN $URL = 'https://github.com/thxCode/containernetworking-plugins/releases/down
     \
     Write-Host 'Complete.'
 # download flanneld
-RUN $URL = 'https://github.com/thxCode/coreos-flannel/releases/download/v0.2.0-rancher/binaries.zip'; \
+RUN $URL = 'https://github.com/thxCode/coreos-flannel/releases/download/v0.3.1-rancher/binaries.zip'; \
     \
     Write-Host ('Downloading flanneld from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \


### PR DESCRIPTION
**Problem:**
v0.2.0-rancher Flannel bases on the console output of the netsh command,
which could not distinguish the none English language system.

**Solution:**
Update to v0.3.0-rancher

**Issue:**
https://github.com/rancher/rancher/issues/23078
