### PR TITLE
Update the related binaries of Windows

### DIFF
--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -3,6 +3,14 @@ ARG SERVERCORE_VERSION
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} as builder
 ARG ARCH=amd64
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) { \
+       Install-PackageProvider -Name NuGet -Force -Verbose; \
+       Install-Module -Name 7Zip4Powershell -Repository PSGallery -Force -Verbose; \
+       if(-not $?) { \
+            Write-Error "Failed to install package"; \
+            Exit 1; \
+       } \
+    }
 # download confd
 RUN $URL = 'https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-windows-amd64.exe'; \
     \
@@ -23,14 +31,39 @@ RUN $URL = 'http://nginx.org/download/nginx-1.15.9.zip'; \
     \
     Write-Host 'Complete.'
 # download cni plugins
-RUN $URL = 'https://github.com/thxCode/containernetworking-plugins/releases/download/v0.2.1-rancher/binaries.zip'; \
+RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz'; \
+    \
+    function DeGZip-File ($inFile, $outFile) { \
+        $input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read); \
+        $output = New-Object System.IO.FileStream $outFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None); \
+        $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress); \
+        try { \
+            if (!$input -or !$output -or !$gzipStream) { \
+                Write-Error "Failed to Unzip the archive"; \
+                Exit 1; \
+            } \
+            $buffer = New-Object byte[](1024); \
+            while ($true) { \
+                $read = $gzipstream.Read($buffer, 0, 1024); \
+                if ($read -le 0 ) { \
+                    break; \
+                } \
+                $output.Write($buffer, 0, $read); \
+            } \
+        } finally { \
+            $gzipStream.Close(); \
+            $output.Close(); \
+            $input.Close(); \
+        } \
+    }; \
     \
     Write-Host ('Downloading cni plugins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:\containernetworking-plugins.zip -Uri $URL; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\containernetworking-plugins.tarz -Uri $URL; \
     \
     Write-Host 'Expanding ...'; \
-    Expand-Archive -Force -Path c:\containernetworking-plugins.zip -DestinationPath c:\containernetworking\.; \
+    DeGZip-File c:\containernetworking-plugins.tarz c:\containernetworking-plugins.tar; \
+    Expand-7Zip c:\containernetworking-plugins.tar c:\containernetworking\bin\.; \
     \
     Write-Host 'Complete.'
 # download flanneld

--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -45,7 +45,7 @@ RUN $URL = 'https://github.com/thxCode/coreos-flannel/releases/download/v0.2.0-r
     \
     Write-Host 'Complete.'
 # download flexvolume plugins
-RUN $URL = 'https://github.com/Microsoft/K8s-Storage-Plugins/releases/download/v0.0.2/flexvolume-windows.zip'; \
+RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V0.0.3/flexvolume-windows.zip'; \
     \
     Write-Host ('Downloading Volume Plugins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \


### PR DESCRIPTION
- The new release of [containernetworking/plugins](https://github.com/containernetworking/plugins/releases/tag/v0.8.2) has included what we needed.
- [microsoft/K8s-Storeage-Plugins](https://github.com/microsoft/K8s-Storage-Plugins/releases/tag/V0.0.3) has released a new version.

**Issue**:
https://github.com/rancher/rancher/issues/20330