### PR TITLE
bind reverse proxy to localhost

### DIFF
--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -15,7 +15,7 @@ stream {
         }
 
         server {
-            listen        6443;
+            listen        localhost:6443;
             proxy_pass    kube_apiserver;
             proxy_timeout 30;
             proxy_connect_timeout 2s;


### PR DESCRIPTION
It looks like the `nginx-proxy` only serves among workers and access by localhost only, while `listen 6443` will publish port externally. 