### PR TITLE
Fix perm of ssl dir for cis tests

### DIFF
--- a/cert-deployer
+++ b/cert-deployer
@@ -2,7 +2,7 @@
 
 SSL_CRTS_DIR=${CRTS_DEPLOY_PATH:-/etc/kubernetes/ssl}
 mkdir -p $SSL_CRTS_DIR
-chmod 700 $SSL_CRTS_DIR
+chmod 755 $SSL_CRTS_DIR
 
 for i in $(env | grep -o KUBE_.*=); do
   name="$(echo "$i" | cut -f1 -d"=" | tr '[:upper:]' '[:lower:]' | tr '_' '-').pem"
@@ -25,11 +25,22 @@ for i in $(env | grep -o KUBECFG_.*=); do
 done
 
 # only enabled if we are running etcd with custom uid/gid
+# change ownership of etcd cert and key and kube-ca to the custom uid/gid
 if [ -n "${ETCD_UID}" ] && [ -n "${ETCD_GID}" ]; then
   # set minial mask to allow effective read access to the certificates
   setfacl -R -m m::rX "${SSL_CRTS_DIR}" && echo "Successfully set ACL mask for certs dir"
-  # allow certs dir read access to the custom etcd uid
-  setfacl -R -m u:${ETCD_UID}:rX "${SSL_CRTS_DIR}" && echo "Successfully set user ACL for certs dir"
+  # we remove certs dir acl if any for the custom etcd uid, since chown will give that access
+  setfacl -R -x u:${ETCD_UID} "${SSL_CRTS_DIR}" && echo "Successfully unset user ACL for certs dir"
   # allow certs dir read access to the custom etcd gid
-  setfacl -R -m g:${ETCD_GID}:rX "${SSL_CRTS_DIR}" && echo "Successfully set group ACL for certs dir"
+  setfacl -R -x g:${ETCD_GID} "${SSL_CRTS_DIR}" && echo "Successfully unset group ACL for certs dir"
+
+  for name in $SSL_CRTS_DIR/*.pem; do
+    if [[ $name == *kube-etcd* ]] ; then
+        chown "${ETCD_UID}":"${ETCD_GID}" $name
+    fi
+    if [[ $name == *kube-ca.pem ]] ; then
+        chmod 644 $name
+    fi
+  done
+  chmod 755 $SSL_CRTS_DIR
 fi


### PR DESCRIPTION
When we allow using custom uid/gid for etcd, we use ACLs to grant the etcd user read permissions to the certificates directory. But that changes the permissions of the certs and key files to 640, instead they need to be at 600 for private key files and 644 or restrictive for public.

600: Only owner can read and write the files. So for etcd to be run using custom uid/gid, that custom user should own the certs that etcd needs.

Hence we need to the set the permissions as these:
- Set certs dir permission at 755 - so that root:root owns it but all other users can list the contents.
- Change ownership of the etcd cert/key  that etcd process uses to custom uid:gid.
- Change permissions of kube-ca.pem to 644 - owned by root:root by readable by etcd user.

