### PR TITLE
Remove unused ARM Build from Manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -220,7 +220,7 @@ name: manifest
 
 steps:
   - name: push-manifest
-    image: ibuildthecloud/manifest:v1.2.3-patch1
+    image: plugins/manifest
     settings:
       username:
         from_secret: docker_username

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -11,11 +11,6 @@ manifests:
       architecture: arm64
       os: linux
   -
-    image: rancher/rke-tools:{{build.tag}}-linux-arm
-    platform:
-      architecture: arm
-      os: linux
-  -
     image: rancher/rke-tools:{{build.tag}}-windows-1809
     platform:
       architecture: amd64


### PR DESCRIPTION
We used to set a param for the plugin to ignore missing images, this PR removes the arm build we never actually used and gets us back to using the upstream plugin which now has darren's changes.