### PR TITLE
Add statefile to recurring snapshots

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -14,6 +14,8 @@ RUN apk -U --no-cache add curl wget ca-certificates tar sysstat acl\
     && chmod +x /usr/bin/confd \
     && curl -sLf ${!DOCKER_URL} | tar xvzf - -C /opt/rke-tools/bin --strip-components=1 docker/docker \
     && chmod +x /opt/rke-tools/bin/docker \
+    && curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.18.2/bin/linux/${ARCH}/kubectl > /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
     && apk del curl
 
 RUN mkdir -p /opt/cni/bin


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2222

This adds a function to retrieve the statefile using kubectl binary when a snapshot is taken using the `etcd-rolling-snapshots` container which is only used in RKE CLI setups (in Rancher this is handled by scheduling one-time snapshots).

I made the choice to add the kubectl binary and use commands to have a more clean implementation, versus vendoring the k8s client libs needed and building a kubectl get command.

The other part is unmarshalling the output into something that we can write to a file. To avoid bringing in all the structs needed to build a fullState, I used maps.

As having a state file in the snapshot archive is not blocking, we don't error out if we can't retrieve the state file (e.g. if kube-apiserver is down/unreachable/busy), because having a snapshot archive without a statefile is better than having no snapshot archive at all.