### PR TITLE
added logic to not unmount the docker containers directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,12 @@ if echo ${@} | grep -q "cloud-provider=azure"; then
   fi
 fi
 
+DOCKER_ROOT=$(DOCKER_API_VERSION=1.24 /opt/rke-tools/bin/docker info 2>&1  | grep -i 'docker root dir' | cut -f2 -d:)
+DOCKER_DIRS=$(find -O1 $DOCKER_ROOT -maxdepth 1) # used to exclude mounts that are subdirectories of $DOCKER_ROOT to ensure we don't unmount mounted filesystems on sub directories
 if [ "$1" = "kubelet" ]; then
-    for i in $(DOCKER_API_VERSION=1.24 /opt/rke-tools/bin/docker info 2>&1  | grep -i 'docker root dir' | cut -f2 -d:) /var/lib/docker /run /var/run; do
+    for i in $DOCKER_ROOT /var/lib/docker /run /var/run; do
         for m in $(tac /proc/mounts | awk '{print $2}' | grep ^${i}/); do
-            if [ "$m" != "/var/run/nscd" ] && [ "$m" != "/run/nscd" ]; then
+            if [ "$m" != "/var/run/nscd" ] && [ "$m" != "/run/nscd" ] && ! echo $DOCKER_DIRS | grep -qF "$m"; then
                 umount $m || true
             fi
         done


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/29275

PROBLEM:

On startup the entrypoint script un-mounts a number of directories including the docker container directory.  This causes errors for some containers such as kubelet when they try to access the docker root directory and container directory.

SOLUTION:

We get the docker root from `docker info`.  The docker root is used to construct the containers directory.  These 2 paths are omitted when the existing mounts are traversed and unmounted.

TESTING:
This was tested by extending the rke hyperkube image with the new entrypoint script and deploying an rke cluster.