### PR TITLE
Fix logic in DeleteBackupAction

### DIFF
--- a/main.go
+++ b/main.go
@@ -697,11 +697,33 @@ func DeleteBackupAction(c *cli.Context) error {
 	if len(folder) != 0 {
 		name = fmt.Sprintf("%s/%s", folder, name)
 	}
-	for _, p := range []string{name, fmt.Sprintf("%s.%s", name, compressedExtension)} {
-		if err = client.RemoveObject(bc.BucketName, p); err != nil {
+
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	objectCh := make(<-chan minio.ObjectInfo)
+	// list objects with prefix=name, this will include uncompressed and compressed backup objects
+	if s3utils.IsGoogleEndpoint(*client.EndpointURL()) {
+		log.Info("Endpoint is Google GCS")
+		objectCh = client.ListObjects(bc.BucketName, name, false, doneCh)
+	} else {
+		objectCh = client.ListObjectsV2(bc.BucketName, name, false, doneCh)
+	}
+	var removed []string
+	for object := range objectCh {
+		if object.Err != nil {
+			log.Errorf("failed to list objects in backup buckets [%s]: %v", bc.BucketName, object.Err)
+			return object.Err
+		}
+		log.Infof("deleting object with key: %s that matches prefix: %s", object.Key, name)
+		err = client.RemoveObject(bc.BucketName, object.Key)
+		if err != nil {
 			return err
 		}
+		removed = append(removed, object.Key)
 	}
+
+	log.Infof("removed backups: %s from object store", strings.Join(removed, ", "))
+
 	return nil
 }
 


### PR DESCRIPTION
Issue:
- rancher/rancher#30565

Prior to these changes, if you had a backup: `backups/backup1.zip`, the logic failed because it tried to delete the uncompressed backup first (`backups/backup1`), which may not exist. An early return was triggered before attempting to delete the compressed backup. 

With the fix, we list objects with prefix: `backups/backup1`, which includes both `backups/backup1` and `backups/backup1.zip`, and subsequently delete the backups returned by the list operation. This will work for compressed and uncompressed files now.

NOTE: Both problems in the issue, deletion of backups past retention time and manual backup deletion, are solved with this fix. This is due to the current rke cluster etcd backup logic being orchestrated by the `management/etdbackup` controller