### PR TITLE
Set proxy timeout to 10m

### DIFF
--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -17,7 +17,7 @@ stream {
         server {
             listen        6443;
             proxy_pass    kube_apiserver;
-            proxy_timeout 30;
+            proxy_timeout 10m;
             proxy_connect_timeout 2s;
 
         }

--- a/windows/templates/nginx.tmpl
+++ b/windows/templates/nginx.tmpl
@@ -16,7 +16,7 @@ stream {
     server {
         listen        6443;
         proxy_pass    kube_apiserver;
-        proxy_timeout 30;
+        proxy_timeout 10m;
         proxy_connect_timeout 2s;
     }
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/31506

Suspect there was previously a heartbeat between kubelet streamwatcher and kube-apiserver.  Now relatively static watches are causing large numbers of logs in the kubelet.  Have tested increasing to 5m and there are 2 consistent watches that continue timing out:
```
*v1beta1.RuntimeClass
*v1.CSIDriver
```

Increasing to 10 minutes resolves these as well