### PR TITLE
Enabling to read etcdbackup s3-accessKey and s3-secretKey parameters as base64 encoded values

### DIFF
--- a/main.go
+++ b/main.go
@@ -730,7 +730,23 @@ func setS3Service(bc *backupConfig, useSSL bool) (*minio.Client, error) {
 				bc.Endpoint = s3Endpoint
 			}
 		} else {
-			cred = credentials.NewStatic(bc.AccessKey, bc.SecretKey, "", credentials.SignatureDefault)
+			// Base64 decoding S3 accessKey and secretKey before create static credentials
+			// To be backward compatible, just updating base64 encoded values
+			accessKey := bc.AccessKey
+			secretKey := bc.SecretKey
+			if len(accessKey) > 0 {
+				v, err := base64.StdEncoding.DecodeString(accessKey)
+				if err == nil {
+					accessKey = string(v)
+				}
+			}
+			if len(secretKey) > 0 {
+				v, err := base64.StdEncoding.DecodeString(secretKey)
+				if err == nil {
+					secretKey = string(v)
+				}
+			}
+			cred = credentials.NewStatic(accessKey, secretKey, "", credentials.SignatureDefault)
 		}
 		client, err = minio.NewWithOptions(bc.Endpoint, &minio.Options{
 			Creds:        cred,


### PR DESCRIPTION
Issue https://github.com/rancherlabs/rancher-security/issues/530

Once merged and rke-tools docker released , kdm update is required

Required by https://github.com/rancher/rke/pull/2490