### PR TITLE
remove 2004 SAC, update versions for windows and dapper

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
   - name: build
-    image: rancher/dapper:v0.5.1
+    image: rancher/dapper:v0.5.7
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -22,7 +22,7 @@ steps:
       - pull_request
       - tag
   - name: stage-binaries
-    image: rancher/dapper:v0.5.1
+    image: rancher/dapper:v0.5.7
     commands:
       - cp -r ./bin/* ./
     when:
@@ -64,7 +64,7 @@ platform:
 
 steps:
   - name: build
-    image: rancher/dapper:v0.5.1
+    image: rancher/dapper:v0.5.7
     volumes:
       - name: docker
         path: /var/run/docker.sock
@@ -79,7 +79,7 @@ steps:
       - pull_request
       - tag
   - name: stage-binaries
-    image: rancher/dapper:v0.5.1
+    image: rancher/dapper:v0.5.7
     commands:
       - cp -r ./bin/* ./
     when:
@@ -148,48 +148,6 @@ volumes:
       path: \\\\.\\pipe\\docker_engine
 ---
 kind: pipeline
-name: windows-2004
-
-platform:
-  os: windows
-  arch: amd64
-  version: 2004
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: luthermonson/drone-git:windows-2004-amd64
-  - name: publish-rke-tools-windows-2004
-    image: luthermonson/drone-docker:2004
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      dockerfile: package/Dockerfile.windows
-      build_args:
-        - SERVERCORE_VERSION=2004
-      repo: rancher/rke-tools
-      tag: "${DRONE_TAG}-windows-2004"
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      refs:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-
----
-kind: pipeline
 name: windows-20H2
 
 platform:
@@ -252,5 +210,4 @@ depends_on:
 - linux-amd64
 - linux-arm64
 - windows-1809
-- windows-2004
 - windows-20H2

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -17,12 +17,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/rke-tools:{{build.tag}}-windows-2004
-    platform:
-      architecture: amd64
-      os: windows
-      version: 2004
-  -
     image: rancher/rke-tools:{{build.tag}}-windows-20H2
     platform:
       architecture: amd64

--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -20,7 +20,7 @@ RUN $URL = 'https://github.com/kelseyhightower/confd/releases/download/v0.16.0/c
     \
     Write-Host 'Complete.'
 # download nginx
-RUN $URL = 'http://nginx.org/download/nginx-1.15.9.zip'; \
+RUN $URL = 'http://nginx.org/download/nginx-1.19.9.zip'; \
     \
     Write-Host ('Downloading nginx from {0} ...'  -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -31,7 +31,7 @@ RUN $URL = 'http://nginx.org/download/nginx-1.15.9.zip'; \
     \
     Write-Host 'Complete.'
 # download cni plugins
-RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz'; \
+RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-windows-amd64-v0.9.1.tgz'; \
     \
     function DeGZip-File ($inFile, $outFile) { \
         $input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read); \
@@ -67,7 +67,7 @@ RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.
     \
     Write-Host 'Complete.'
 # download flanneld
-RUN $URL = 'https://github.com/luthermonson/flannel/releases/download/v0.12.0-rancher1/flanneld.exe'; \
+RUN $URL = 'https://github.com/flannel-io/flannel/releases/download/v0.15.0/flanneld.exe'; \
 	New-Item -Path c:\ -Name "flanneld" -ItemType "directory"; \
     Write-Host ('Downloading flanneld from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -93,7 +93,7 @@ RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; 
     \
     Write-Host 'Complete.'
 # download GetGcePdName.dll
-# this's a stopgap, we could drop this after https://github.com/kubernetes/kubernetes/issues/74674 fixed
+# https://github.com/kubernetes/kubernetes/issues/74674#issuecomment-520200497 issue closed, use of csi-proxy is the fix
 RUN $URL = 'https://github.com/pjh/gce-tools/raw/master/GceTools/GetGcePdName/GetGcePdName.dll'; \
     \
     Write-Host ('Downloading GetGcePdName DLL from {0}...'  -f $URL); \
@@ -106,7 +106,7 @@ FROM mcr.microsoft.com/powershell:nanoserver-${SERVERCORE_VERSION}
 USER ContainerAdministrator
 COPY --from=builder /Windows/System32/netapi32.dll /Windows/System32/
 COPY --from=builder /wins.exe /confd.exe /Windows/
-COPY --from=builder /nginx-1.15.9 /etc/nginx
+COPY --from=builder /nginx-1.19.9 /etc/nginx
 COPY --from=builder /containernetworking/bin/host-local.exe /containernetworking/bin/flannel.exe /containernetworking/bin/win-overlay.exe /containernetworking/bin/win-bridge.exe /opt/cni/bin/
 COPY --from=builder /flanneld/flanneld.exe /opt/bin/
 COPY --from=builder /flexvolume /share/kubelet-volumeplugins

--- a/package/Dockerfile.windows.20H2
+++ b/package/Dockerfile.windows.20H2
@@ -20,7 +20,7 @@ RUN $URL = 'https://github.com/kelseyhightower/confd/releases/download/v0.16.0/c
     \
     Write-Host 'Complete.'
 # download nginx
-RUN $URL = 'http://nginx.org/download/nginx-1.15.9.zip'; \
+RUN $URL = 'http://nginx.org/download/nginx-1.19.9.zip'; \
     \
     Write-Host ('Downloading nginx from {0} ...'  -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -31,7 +31,7 @@ RUN $URL = 'http://nginx.org/download/nginx-1.15.9.zip'; \
     \
     Write-Host 'Complete.'
 # download cni plugins
-RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz'; \
+RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-windows-amd64-v0.9.1.tgz'; \
     \
     function DeGZip-File ($inFile, $outFile) { \
         $input = New-Object System.IO.FileStream $inFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read); \
@@ -67,7 +67,7 @@ RUN $URL = 'https://github.com/containernetworking/plugins/releases/download/v0.
     \
     Write-Host 'Complete.'
 # download flanneld
-RUN $URL = 'https://github.com/luthermonson/flannel/releases/download/v0.12.0-rancher1/flanneld.exe'; \
+RUN $URL = 'https://github.com/flannel-io/flannel/releases/download/v0.15.0/flanneld.exe'; \
 	New-Item -Path c:\ -Name "flanneld" -ItemType "directory"; \
     Write-Host ('Downloading flanneld from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -93,7 +93,7 @@ RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; 
     \
     Write-Host 'Complete.'
 # download GetGcePdName.dll
-# this's a stopgap, we could drop this after https://github.com/kubernetes/kubernetes/issues/74674 fixed
+# https://github.com/kubernetes/kubernetes/issues/74674#issuecomment-520200497 issue closed, use of csi-proxy is the fix
 RUN $URL = 'https://github.com/pjh/gce-tools/raw/master/GceTools/GetGcePdName/GetGcePdName.dll'; \
     \
     Write-Host ('Downloading GetGcePdName DLL from {0}...'  -f $URL); \
@@ -108,7 +108,7 @@ RUN $URL = 'https://github.com/pjh/gce-tools/raw/master/GceTools/GetGcePdName/Ge
 RUN Move-Item -Path /wins.exe -Destination /Windows/
 RUN Move-Item -Path /confd.exe -Destination /Windows/
 RUN New-Item -Force -ItemType Directory -Path /etc; \
-    Move-Item -Path /nginx-1.15.9 -Destination /etc/nginx
+    Move-Item -Path /nginx-1.19.9 -Destination /etc/nginx
 RUN New-Item -Force -ItemType Directory -Path /opt; \
     New-Item -Force -ItemType Directory -Path /opt/cni; \
     New-Item -Force -ItemType Directory -Path /opt/bin; \


### PR DESCRIPTION
- Remove Windows Server 2004 SAC build steps
- Update versions in Windows dockerfiles
- Update dapper version in drone file