### PR TITLE
cri-dockerd adds pod-infra-container-image parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,10 @@ if [ "$1" = "kubelet" ]; then
 
     # separate flow for cri-dockerd to minimize change to the existing way we run kubelet
     if [ "${RKE_KUBELET_CRIDOCKERD}" == "true" ]; then
-        /opt/rke-tools/bin/cri-dockerd --network-plugin="cni" --cni-conf-dir="/etc/cni/net.d" --cni-bin-dir="/opt/cni/bin" &
+        
+        # Get the value of pause image to start cri-dockerd
+        RKE_KUBELET_PAUSEIMAGE=$(echo "$@" | grep -Eo "\-\-pod-infra-container-image+.*" | awk '{print $1}')
+        /opt/rke-tools/bin/cri-dockerd --network-plugin="cni" --cni-conf-dir="/etc/cni/net.d" --cni-bin-dir="/opt/cni/bin" ${RKE_KUBELET_PAUSEIMAGE} &
 
         # wait for cri-dockerd to start as kubelet depends on it
         echo "Sleeping 10 waiting for cri-dockerd to start"


### PR DESCRIPTION
Support specified pause image by adding pod-infra-container-image
```
# ps -ef |grep cri-dockerd | grep -v grep
root     15148 14794  7 13:43 ?        00:00:47 /opt/rke-tools/bin/cri-dockerd --network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin --pod-infra-container-image=rancher/mirrored-pause:3.4.1
```

Related Issue: https://github.com/rancher/rancher/issues/35555