### PR TITLE
set hostname for kube-proxy if cloud provider is aws

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,13 @@ if echo ${@} | grep -q "cloud-provider=azure"; then
   fi
 fi
 
+if [ "$1" = "kube-proxy" ]; then
+  if echo ${@} | grep -v "hostname-override"; then
+    hostname=$(curl "http://169.254.169.254/latest/meta-data/hostname")
+    set ${@} --hostname-override=$hostname
+  fi
+fi
+
 if [ "$1" = "kubelet" ]; then
     DOCKER_ROOT=$(DOCKER_API_VERSION=1.24 /opt/rke-tools/bin/docker info 2>&1  | grep -i 'docker root dir' | cut -f2 -d:)
     DOCKER_DIRS=$(find -O1 $DOCKER_ROOT -maxdepth 1) # used to exclude mounts that are subdirectories of $DOCKER_ROOT to ensure we don't unmount mounted filesystems on sub directories


### PR DESCRIPTION
**Issue:**
https://github.com/rancher/rancher/issues/30363 - kubelet uses nodename set by aws cloud provider, but kube-proxy doesn't. kube-proxy expects the hostname to be the same as the nodename, otherwise it doesn't set the right iptables rules. 

**Fix:**
Getting nodename from instance metadata and passing it via hostname-override so kube-proxy gets the expected hostname.

This requires fix from RKE (https://github.com/rancher/rke/pull/2803) that removes hostname-override flag
from kube-proxy command args for aws cloud provider so it can
be set here in rke-tools.
