### PR TITLE
Bump to nginx:1.21.6-alpine

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.0-alpine
+FROM nginx:1.21.6-alpine
 
 LABEL maintainer "Rancher Labs <support@rancher.com>"
 ARG ARCH=amd64


### PR DESCRIPTION
Bump nginx-alpine version to fix some CVEs in Alpine base image.