### PR TITLE
bump wins to v0.2.1 and cni plugin to 0.9.1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -23,7 +23,7 @@ RUN apk -U --no-cache add curl wget ca-certificates tar sysstat acl\
     && apk del curl
 
 RUN mkdir -p /opt/cni/bin
-RUN wget -q -O - https://github.com/containernetworking/cni/releases/download/v0.9.1/cni-${ARCH}-v0.9.1.tgz | tar xzf - -C /tmp
+RUN wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-${ARCH}-v0.9.1.tgz | tar xzf - -C /tmp
 RUN wget -q -O /tmp/portmap https://github.com/rancher/plugins/releases/download/v1.9.1-rancher1/portmap-${ARCH}
 
 ENV ETCD_URL=https://github.com/etcd-io/etcd/releases/download/v3.4.15/etcd-v3.4.15-linux-${ARCH}.tar.gz

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -23,7 +23,7 @@ RUN apk -U --no-cache add curl wget ca-certificates tar sysstat acl\
     && apk del curl
 
 RUN mkdir -p /opt/cni/bin
-RUN wget -q -O - https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-${ARCH}-v0.4.0.tgz | tar xzf - -C /tmp
+RUN wget -q -O - https://github.com/containernetworking/cni/releases/download/v0.9.1/cni-${ARCH}-v0.9.1.tgz | tar xzf - -C /tmp
 RUN wget -q -O /tmp/portmap https://github.com/rancher/plugins/releases/download/v1.9.1-rancher1/portmap-${ARCH}
 
 ENV ETCD_URL=https://github.com/etcd-io/etcd/releases/download/v3.4.15/etcd-v3.4.15-linux-${ARCH}.tar.gz

--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1-patch1/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.2.1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1-patch1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/package/Dockerfile.windows.20H2
+++ b/package/Dockerfile.windows.20H2
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1-patch1/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.2.1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/package/Dockerfile.windows.20H2
+++ b/package/Dockerfile.windows.20H2
@@ -85,7 +85,7 @@ RUN $URL = 'https://github.com/microsoft/K8s-Storage-Plugins/releases/download/V
     \
     Write-Host 'Complete.'
 # download wins
-RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe'; \
+RUN $URL = 'https://github.com/rancher/wins/releases/download/v0.1.1-patch1/wins.exe'; \
     \
     Write-Host ('Downloading wins from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/windows/sidecar.ps1
+++ b/windows/sidecar.ps1
@@ -293,7 +293,7 @@ if ($networkConfigObj)
 
             $winsArgs = $($flannelArgs -join ' ')
             Log-Info "Start flanneld with: $winsArgs"
-            wins.exe cli prc run --path "$prefixPath\opt\bin\flanneld.exe" --exposes ("UDP:{0}" -f $port) --args "$winsArgs" --envs "NODE_NAME=$nodeName"
+            wins.exe cli prc run --path "$prefixPath\opt\bin\flanneld.exe" --exposes ("UDP:{0}" -f $port) --envs "NODE_NAME=$nodeName" --args "$winsArgs"
         }
     }
 


### PR DESCRIPTION
the linux rke-tools image has had v0.0.4 of the cni plugins packaged in it. This PR brings the cni version into alignment with the latest available without switching to the stable version which introduces issues due to flannel cni being removed from upstream cni plugin releases.

this also bumps wins to v0.2.1 which fixes a regression introduced in v0.1.79 of rke-tools that was not present in v0.1.78