### PR TITLE
Removing all Windows 20H2 support since it is EOL August 9th.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -146,47 +146,7 @@ volumes:
   - name: docker_pipe
     host:
       path: \\\\.\\pipe\\docker_engine
----
-kind: pipeline
-name: windows-20H2
 
-platform:
-  os: windows
-  arch: amd64
-  version: 20H2
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: luthermonson/drone-git:windows-20H2-amd64
-  - name: publish-rke-tools-windows-20H2
-    image: luthermonson/drone-docker:20H2
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      dockerfile: package/Dockerfile.windows.20H2
-      build_args:
-        - SERVERCORE_VERSION=20H2
-      repo: rancher/rke-tools
-      tag: "${DRONE_TAG}-windows-20H2"
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      refs:
-        - refs/head/master
-        - refs/tags/*
-      event:
-        - tag
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
 ---
 kind: pipeline
 name: manifest
@@ -210,4 +170,3 @@ depends_on:
 - linux-amd64
 - linux-arm64
 - windows-1809
-- windows-20H2

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -16,9 +16,3 @@ manifests:
       architecture: amd64
       os: windows
       version: 1809
-  -
-    image: rancher/rke-tools:{{build.tag}}-windows-20H2
-    platform:
-      architecture: amd64
-      os: windows
-      version: 20H2


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This removes Windows 20H2 from the build, images, tests, and manifest since it is EOL come August 9th, 2022.

* https://github.com/rancher/windows/issues/113

### Occurred changes and/or fixed issues

Removed the build pipeline, manifest entry, and tests for Windows 2022.