### PR TITLE
bind kubelet config to default docker config path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,13 @@ if [ "$1" = "kubelet" ]; then
 
     # separate flow for cri-dockerd to minimize change to the existing way we run kubelet
     if [ "${RKE_KUBELET_CRIDOCKERD}" == "true" ]; then
+
+        # Mount kubelet docker config to /.docker/config.json
+        if [ ! -z "${RKE_KUBELET_DOCKER_CONFIG}" ]
+        then
+          mkdir -p /.docker && touch /.docker/config.json
+          mount --bind ${RKE_KUBELET_DOCKER_FILE} /.docker/config.json
+        fi
         
         # Get the value of pause image to start cri-dockerd
         RKE_KUBELET_PAUSEIMAGE=$(echo "$@" | grep -Eo "\-\-pod-infra-container-image+.*" | awk '{print $1}')


### PR DESCRIPTION
https://github.com/rancher/rke/pull/3002 change doesn't work if `/var/lib/kubelet/config.json` doesn't exist. In this case, mounting a non-existent file location creates a directory and then mounts the directory. So no auth config gets stored and kubelet errors out when pulling images using private registry. 

So, need to revert the mount added in `extra_binds` for kubelet and move the logic to `entrypoint.sh` in rke-tools to ensure mount bind happens only after the file is created. 