### PR TITLE
Add dualstack flag if multiple CIDR are configured

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,11 @@ if [ "$1" = "kubelet" ]; then
           # cri-dockerd v0.3.1 requires unix socket or tcp endpoint, update old endpoint passed by rke
           CONTAINER_RUNTIME_ENDPOINT="unix://$CONTAINER_RUNTIME_ENDPOINT"
         fi
-        /opt/rke-tools/bin/cri-dockerd --network-plugin="cni" --cni-conf-dir="/etc/cni/net.d" --cni-bin-dir="/opt/cni/bin" ${RKE_KUBELET_PAUSEIMAGE} --container-runtime-endpoint=$CONTAINER_RUNTIME_ENDPOINT &
+        EXTRA_FLAGS=""
+        if [ "${RKE_KUBELET_CRIDOCKERD_DUALSTACK}" == "true" ]; then
+          EXTRA_FLAGS="--ipv6-dual-stack"
+        fi
+        /opt/rke-tools/bin/cri-dockerd --network-plugin="cni" --cni-conf-dir="/etc/cni/net.d" --cni-bin-dir="/opt/cni/bin" ${RKE_KUBELET_PAUSEIMAGE} --container-runtime-endpoint=$CONTAINER_RUNTIME_ENDPOINT ${EXTRA_FLAGS} &
 
         # wait for cri-dockerd to start as kubelet depends on it
         echo "Sleeping 10 waiting for cri-dockerd to start"


### PR DESCRIPTION
https://github.com/rancher/rke/issues/3271

This will add the required flag if dual-stack is configured, the environment variable is set by RKE (see https://github.com/rancher/rke/pull/3272)