### PR TITLE
Fix entrypoint.sh for kubelet on cri-dockerd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,7 @@ if [ "$1" = "kubelet" ]; then
 
         # waiting for either cri-dockerd or kubelet to crash and exit so it can be restarted
         wait -n
+        exit $?
     else
         # start kubelet
         exec "$@" --cgroup-driver=$CGROUPDRIVER $RESOLVCONF


### PR DESCRIPTION
This PR is related to https://github.com/rancher/rke/issues/3292

Adding an `exit` after the `wait -n` ensures the program's exit after either `cri-dockerd` or `kubelet` exits.
Most likely was an oversight on `wait`'s behaviour as the comment mentions `waiting for either cri-dockerd or kubelet to crash and exit`.

This change prevents the L114 `exec "$@"` to be executed after `cri-dockerd` or `kubelet` exits.