### PR TITLE
Run iptables-wrapper every time the container starts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -x
 
+# Evaluate the iptables mode every time the container starts (fixes OS upgrades changing mode)
+if [ "$1" = "kubelet" ] || [ "$1" = "kube-proxy" ]; then
+  update-alternatives --set iptables /usr/sbin/iptables-wrapper
+fi
+
 # generate Azure cloud provider config
 if echo ${@} | grep -q "cloud-provider=azure"; then
   if [ "$1" = "kubelet" ] || [ "$1" = "kube-apiserver" ] || [ "$1" = "kube-controller-manager" ]; then


### PR DESCRIPTION
Without this PR, iptables mode is only evaluated the first time the container is deployed. Restarts of the container will not change the iptables mode. As a consequence, we were having this bug: https://jira.suse.com/browse/SURE-6603.

This PR makes sure that the iptables mode gets evaluated everytime the pod is started, e.g. during a reboot of the hostOS


Issue: https://github.com/rancher/rancher/issues/42103