### PR TITLE
Add workflow to automatically tag and release

### DIFF
--- a/.github/workflows/create-tag-release.yml
+++ b/.github/workflows/create-tag-release.yml
@@ -1,0 +1,54 @@
+name: Create tag and release
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create tag and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+      - name: Generate new tag
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0)
+          # Bump last field (NF) by 1
+          bump_patch=$(echo "${latest_tag}" | awk -F. '{OFS="."; $NF+=1; print $0}')
+          echo "generated_tag=${bump_patch}" >> $GITHUB_OUTPUT
+          echo "Generated tag: ${bump_patch}" >> $GITHUB_STEP_SUMMARY
+        id: generate_tag
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = '${{ steps.generate_tag.outputs.generated_tag }}'
+
+            try {
+              const resp = await github.rest.git.getRef({...context.repo, ref: `tags/${tag}`});
+              return core.setFailed(`the tag ${tag} already exists on ${resp.data.object.type} ${resp.data.object.sha}`);
+            } catch(err) {
+              if(err.status !== 404){
+                throw err;
+              }
+            }
+
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tag}`,
+              sha: context.sha
+            })
+      - name: Create release from tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_URL=$(gh release create ${{ steps.generate_tag.outputs.generated_tag }} --generate-notes)
+          echo "Created release: ${RELEASE_URL}" >> $GITHUB_STEP_SUMMARY 


### PR DESCRIPTION
Workflow to automate what is currently happening manually, it will create a new tag + release on every push to master (and you can run the workflow manually if needed)

- List current latest tag
- Generate new tag by bumping last field by 1 (yes this is not 100% semver bump logic but works and if we ever go minor bump, we can easily adjust)
- Create tag
- Create release from tag

There are some existing Actions but they are either:

- Barely maintained/updated
- Not fully functional for what we need

It also limits us to change or adjust if we need anything, these steps are very clear (imo) and easily adjustable by using simple and readable commands.

Next step in this process would be to automatically bump unreleased Rancher k8s versions with the new tag, but this is the first step.