### PR TITLE
Fix rke-etcd-backup file permissions

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,6 +63,9 @@ jobs:
         with:
           name: rke-etcd-backup-${{ github.run_number }}-${{ github.run_attempt }}
           path: .
+      - name: Fix permissions
+        run: |
+          chmod 755 rke-etcd-backup
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Ref: https://github.com/rancher/rancher/issues/45376

Fix the file permissions for rke-etcd-backup after downloading the artifact.
Default permission gets set to `644`