### PR TITLE
Migrate the base image to `bci-busybox`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,86 +1,102 @@
+ARG BCI_VERSION=15.6
 FROM rancher/hardened-cni-plugins:v1.5.1-build20240910 as cni_base
 
-FROM nginx:1.27.1-alpine as base
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} as final-base
+FROM tonistiigi/xx:1.5.0 AS xx
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} as build
 
+ENV NGINX_VERSION=1.27.1
 ENV DOCKER_VERSION=27.1.1
 ENV ETCD_VERSION=v3.5.16
 ENV CRIDOCKERD_VERSION=0.3.15
 ENV RANCHER_CONFD_VERSION=v0.16.6
 ENV KUBECTL_VERSION=v1.28.11
 
-LABEL maintainer "Rancher Labs <support@rancher.com>"
 ARG ARCH=amd64
 ENV DOCKER_URL_amd64="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
     DOCKER_URL_arm64="https://download.docker.com/linux/static/stable/aarch64/docker-${DOCKER_VERSION}.tgz" \
     DOCKER_URL="DOCKER_URL_${ARCH}"
 ENV CRIDOCKERD_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRIDOCKERD_VERSION}/cri-dockerd-${CRIDOCKERD_VERSION}.${ARCH}.tgz"
-RUN apk -U upgrade \
-    && apk -U --no-cache add bash \
-    && rm -f /bin/sh \
-    && ln -s /bin/bash /bin/sh
-RUN apk -U --no-cache add curl wget ca-certificates tar sysstat acl\
-    && mkdir -p /opt/rke-tools/bin /etc/confd \
-    && curl -sLf "https://github.com/rancher/confd/releases/download/${RANCHER_CONFD_VERSION}/confd-${RANCHER_CONFD_VERSION}-linux-${ARCH}" > /usr/bin/confd \
-    && chmod +x /usr/bin/confd \
-    && curl -sLf "${!DOCKER_URL}" | tar xvzf - -C /opt/rke-tools/bin --strip-components=1 docker/docker \
-    && curl -sLf "${CRIDOCKERD_URL}" | tar xvzf - -C /opt/rke-tools/bin --strip-components=1 cri-dockerd/cri-dockerd \
-    && chmod +x /opt/rke-tools/bin/cri-dockerd \
-    && curl -sLf "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" > /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl \
-    && apk del curl
 
-RUN mkdir -p /opt/cni/bin
+RUN mkdir -p \
+    /chroot \
+    /chroot/opt/rke-tools/bin \
+    /chroot/etc/confd \
+    /opt/cni/bin
 
-COPY --from=cni_base /opt/cni/bin /tmp
+COPY --from=final-base / /chroot/
+
+RUN rm -f /chroot/bin/sh && ln -s /chroot/bin/bash /chroot/bin/sh
+
+RUN zypper refresh && \
+    zypper -n in wget file
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n in acl bash && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/etc/zypp/
+
+RUN wget -q -O /chroot/usr/bin/confd "https://github.com/rancher/confd/releases/download/${RANCHER_CONFD_VERSION}/confd-${RANCHER_CONFD_VERSION}-linux-${ARCH}" && \
+    chmod +x /chroot/usr/bin/confd
+
+RUN wget -q -O - "${!DOCKER_URL}" | tar xvzf - -C /chroot/opt/rke-tools/bin --strip-components=1 docker/docker
+RUN wget -q -O - "${CRIDOCKERD_URL}" | tar xvzf - -C /chroot/opt/rke-tools/bin --strip-components=1 cri-dockerd/cri-dockerd \
+    && chmod +x /chroot/opt/rke-tools/bin/cri-dockerd
+RUN wget -q -O /chroot/usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+    && chmod +x /chroot/usr/local/bin/kubectl
 
 ENV ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${ARCH}.tar.gz
 
 RUN wget -q -O - "${ETCD_URL}" | tar xzf - -C /tmp && \
-    mv /tmp/etcd-*/etcdctl /usr/local/bin/etcdctl && \
-    rm -rf /tmp/etcd-* && rm -f /etcd-*.tar.gz && \
-    apk del wget
+    mv /tmp/etcd-*/etcdctl /chroot/usr/local/bin/etcdctl
 
-COPY templates /etc/confd/templates/
-COPY conf.d /etc/confd/conf.d/
-COPY cert-deployer nginx-proxy /usr/bin/
-COPY entrypoint.sh cloud-provider.sh weave-plugins-cni.sh /opt/rke-tools/
-COPY rke-etcd-backup /opt/rke-tools
+COPY templates /chroot/etc/confd/templates/
+COPY conf.d /chroot/etc/confd/conf.d/
+COPY cert-deployer nginx-proxy /chroot/usr/bin/
+COPY entrypoint.sh cloud-provider.sh weave-plugins-cni.sh /chroot/opt/rke-tools/
+COPY rke-etcd-backup /chroot/opt/rke-tools
 
-VOLUME /opt/rke-tools
-CMD ["/bin/bash"]
+RUN mkdir -p /opt/cni/bin
 
-# Temporary image mostly to verify all binaries exist and are
-# valid for the target architecture.
-FROM tonistiigi/xx:1.4.0 AS xx
-FROM base as test
-COPY --from=xx / /
+COPY --from=cni_base /opt/cni/bin /chroot/tmp
 
 ARG TARGETOS=linux
 ARG TARGETARCH=${ARCH}
 
-RUN xx-verify --static /tmp/bandwidth \
-    && xx-verify --static /tmp/bridge \
-    && xx-verify --static /tmp/dhcp \
-    && xx-verify --static /tmp/firewall \
-    && xx-verify --static /tmp/flannel \
-    && xx-verify --static /tmp/host-device \
-    && xx-verify --static /tmp/host-local \
-    && xx-verify --static /tmp/ipvlan \
-    && xx-verify --static /tmp/loopback \
-    && xx-verify --static /tmp/macvlan \
-    && xx-verify --static /tmp/portmap \
-    && xx-verify --static /tmp/ptp \
-    && xx-verify --static /tmp/sbr \
-    && xx-verify --static /tmp/static \
-    && xx-verify --static /tmp/tuning \
-    && xx-verify --static /tmp/vlan \
-    && xx-verify --static /tmp/vrf
+# Verify key files that will be copied to the final
+# image exist and are statically linked to the target
+# architecture.
+COPY --from=xx / /
+RUN mkdir -p /run/lock
+RUN xx-verify --static /chroot/tmp/bandwidth \
+    && xx-verify --static /chroot/tmp/bridge \
+    && xx-verify --static /chroot/tmp/dhcp \
+    && xx-verify --static /chroot/tmp/firewall \
+    && xx-verify --static /chroot/tmp/flannel \
+    && xx-verify --static /chroot/tmp/host-device \
+    && xx-verify --static /chroot/tmp/host-local \
+    && xx-verify --static /chroot/tmp/ipvlan \
+    && xx-verify --static /chroot/tmp/loopback \
+    && xx-verify --static /chroot/tmp/macvlan \
+    && xx-verify --static /chroot/tmp/portmap \
+    && xx-verify --static /chroot/tmp/ptp \
+    && xx-verify --static /chroot/tmp/sbr \
+    && xx-verify --static /chroot/tmp/static \
+    && xx-verify --static /chroot/tmp/tuning \
+    && xx-verify --static /chroot/tmp/vlan \
+    && xx-verify --static /chroot/tmp/vrf
 
-RUN xx-verify --static /opt/rke-tools/bin/cri-dockerd \
-    && xx-verify --static /opt/rke-tools/bin/docker \
-    && xx-verify --static /opt/rke-tools/rke-etcd-backup
+RUN xx-verify --static /chroot/opt/rke-tools/bin/cri-dockerd \
+    && xx-verify --static /chroot/opt/rke-tools/bin/docker \
+    && xx-verify --static /chroot/opt/rke-tools/rke-etcd-backup
 
-RUN xx-verify --static /usr/bin/confd \
-    && xx-verify --static /usr/local/bin/kubectl
+RUN xx-verify --static /chroot/usr/bin/confd \
+    && xx-verify --static /chroot/usr/local/bin/kubectl
 
-FROM base as final
+
+FROM scratch as final
+COPY --from=build /chroot /
+
+LABEL maintainer "Rancher Labs <support@rancher.com>"
+
+VOLUME /opt/rke-tools
+CMD ["/bin/bash"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,12 +5,12 @@ FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} as final-base
 FROM tonistiigi/xx:1.5.0 AS xx
 FROM registry.suse.com/bci/bci-base:${BCI_VERSION} as build
 
-ENV NGINX_VERSION=1.27.1
-ENV DOCKER_VERSION=27.1.1
+ENV NGINX_VERSION=1.27.2
+ENV DOCKER_VERSION=27.1.2
 ENV ETCD_VERSION=v3.5.16
 ENV CRIDOCKERD_VERSION=0.3.15
 ENV RANCHER_CONFD_VERSION=v0.16.6
-ENV KUBECTL_VERSION=v1.28.11
+ENV KUBECTL_VERSION=v1.28.13
 
 ARG ARCH=amd64
 ENV DOCKER_URL_amd64="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \


### PR DESCRIPTION
Issues:
* https://github.com/rancher/rancher/issues/46099
* https://github.com/rancher/rancher/issues/46626
* https://github.com/rancher/rancher/issues/46627

The aim of this change is to decrease the long-term number of CVEs this image gets due to the decreased attack surface. As a result, the final image is 40MB lighter and does not contain the following commands:

```
add-shell
bbconfig
blkdiscard
busybox
chroot
cifsiostat
c_rehash
crond
crontab
depmod
dumpkmap
envsubst
fbsplash
fc-conflist
fc-list
fc-match
fc-pattern
fc-query
fc-scan
fc-validate
fdflush
fstrim
geoiplookup6
getty
halt
hwclock
ifconfig
ifdown
ifenslave
ifup
init
inotifyd
insmod
iostat
ipaddr
iplink
ipneigh
iproute
iprule
kbd_mode
link
linux32
linux64
logread
lsmod
modinfo
modprobe
mountpoint
ntpd
partprobe
printenv
raidautorun
rdate
rdev
readahead
reboot
remove-shell
rev
rfkill
rmmod
route
swapoff
swapon
syslogd
tapestat
traceroute6
tree
unlzop
watchdog
xsltproc
```

The list above was generated by [comparing](https://gist.github.com/pjbgf/ca686b7be1b7ebc67eeb90c543375ac5) a local image with the previous tagged version:
```
DIRS="/usr/local/bin /usr/sbin /usr/bin /sbin /bin /opt/rke-tools/bin /opt/rke-tools /tmp" diff.sh rancher/rke-tools v0.1.99 dev
```