### PR TITLE
Copy CNI plugins from rancher/hardened-cni-plugins image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,8 @@
+FROM rancher/hardened-cni-plugins:v1.5.1-build20240910 as cni_base
+
 FROM nginx:1.27.1-alpine as base
 
 ENV DOCKER_VERSION=27.1.1
-ENV CNI_PLUGINS_VERSION=v1.5.1
-ENV FLANNEL_VERSION=v1.5.1-flannel1
 ENV ETCD_VERSION=v3.5.16
 ENV CRIDOCKERD_VERSION=0.3.15
 ENV RANCHER_CONFD_VERSION=v0.16.6
@@ -30,9 +30,8 @@ RUN apk -U --no-cache add curl wget ca-certificates tar sysstat acl\
     && apk del curl
 
 RUN mkdir -p /opt/cni/bin
-RUN wget -q -O - https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGINS_VERSION}.tgz | tar xzf - -C /tmp \
-    && wget -q -O /tmp/flannel "https://github.com/flannel-io/cni-plugin/releases/download/${FLANNEL_VERSION}/flannel-${ARCH}" \
-    && chmod +x /tmp/flannel
+
+COPY --from=cni_base /opt/cni/bin /tmp
 
 ENV ETCD_URL=https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${ARCH}.tar.gz
 


### PR DESCRIPTION
## Update
- Update CNI plugins source from https://github.com/containernetworking/plugins to https://github.com/rancher/image-build-cni-plugins

## Test
- Tested by deploying k8s v1.30.5 with `flannel`, `calico` and `canal` on rancher server v2.10-head
![image](https://github.com/user-attachments/assets/3d7dd9e5-8173-48d0-8125-2c3b7ef9df60)


## Issue
- https://github.com/rancher/rancher/issues/47464