### PR TITLE
Update the workflow to build `rke-etcd-backup` binary in `build-and-push` job

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -34,14 +34,6 @@ jobs:
       - name: Build
         run: |
           ./scripts/ci
-      - name: Upload rke-etcd-backup artifact
-        if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: actions/upload-artifact@v4
-        with:
-          name: rke-etcd-backup-${{ github.run_number }}-${{ github.run_attempt }}
-          path: bin/rke-etcd-backup
-          if-no-files-found: error
-          retention-days: 1
 
   build-and-push:
     permissions:
@@ -58,13 +50,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Download rke-etcd-backup artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: rke-etcd-backup-${{ github.run_number }}-${{ github.run_attempt }}
-          path: .
+      - name: Setup Go
+        uses: actions/setup-go@v5
+      - name: Build
+        run: |
+          ./scripts/build
+        env:
+          GOARCH: ${{ matrix.arch }}
       - name: Fix permissions
         run: |
+          mv bin/rke-etcd-backup .
           chmod 755 rke-etcd-backup
       - name: Docker meta
         id: meta


### PR DESCRIPTION
### Updates
- Update the workflow to build `rke-etcd-backup` binary in `build-and-push` job

### Issues
- Failing GHA for arm64: https://github.com/rancher/rke-tools/actions/runs/11512068285/job/32046918193