### PR TITLE
VEX related improvements in the build process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module rke-tools
+module github.com/rancher/rke-tools
 
 go 1.22
 

--- a/scripts/build
+++ b/scripts/build
@@ -7,4 +7,4 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rke-etcd-backup
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/rke-etcd-backup .


### PR DESCRIPTION
The VEX Hub initiative in [rancher/vexhub](https://github.com/rancher/vexhub) is now a mature project in Rancher where we generate VEX reports for known false-positive CVEs in our projects (images and binaries).

In order for VEX to fully work and for security scanners (e.g., Trivy) to correctly match a VEX entry in our VEX Hub with a Go binary being scanned, the Go binary must have its full package path inside of it. Example:

```
> go version -m bin/rke-etcd-backup | head -n 3
bin/rke-etcd-backup: go1.23.4
	path	github.com/rancher/rke-tools
	mod	github.com/rancher/rke-tools	(devel)	
```

Given that the repo's full address wasn't specified in the `go.mod` file, the current generated path is partial.

```
> go version -m bin/rke-etcd-backup | head -n 3
bin/rke-etcd-backup: go1.23.4
	path	rke-tools
	mod	rke-tools	(devel)	
```

In the above case, the security scanner won't be able to match the binary with its respective VEX entry.

This PR isn't expected to affect the code's behavior and features, because it's only metadata information.