### PR TITLE
[v1.32] Bump golang to 1.23

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/rke-tools
 
-go 1.22
+go 1.23
 
-toolchain go1.22.8
+toolchain go1.23.6
 
 require (
 	github.com/minio/minio-go/v7 v7.0.74


### PR DESCRIPTION
### Updates
- Bump golang to 1.23

### Issue:
- https://github.com/rancher/rancher/issues/47934